### PR TITLE
Fix NullPointerException by returning default cell content, and add HitPolicy to StaticInputOutputDetectionStrategy constructor

### DIFF
--- a/xlsx-dmn-cli/src/main/java/org/camunda/bpm/dmn/xlsx/cli/CommandLineConverter.java
+++ b/xlsx-dmn-cli/src/main/java/org/camunda/bpm/dmn/xlsx/cli/CommandLineConverter.java
@@ -65,9 +65,9 @@ public class CommandLineConverter {
 
       if ("--policy".equals(args[i])) {
         try {
-          policy = HitPolicy.valueOf(args[i].toUpperCase());
+          policy = HitPolicy.valueOf(args[i + 1].toUpperCase());
         } catch (Exception e) {
-          System.out.println("Invalid policy argument: " + policy);
+          System.out.println("Invalid policy argument: " + args[i + 1]);
           System.out.println("Continuing without policy...");
         }
       }

--- a/xlsx-dmn-cli/src/main/java/org/camunda/bpm/dmn/xlsx/cli/CommandLineConverter.java
+++ b/xlsx-dmn-cli/src/main/java/org/camunda/bpm/dmn/xlsx/cli/CommandLineConverter.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.dmn.xlsx.XlsxConverter;
 import org.camunda.bpm.dmn.xlsx.api.SpreadsheetAdapter;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.dmn.HitPolicy;
 
 /**
  * @author Thorben Lindhauer
@@ -36,7 +37,7 @@ public class CommandLineConverter {
     if (args.length == 0) {
       final String LINE_SEPARATOR = System.getProperty("line.separator");
       StringBuilder sb = new StringBuilder();
-      sb.append("Usage: java -jar ...jar [--inputs A,B,C,..] [--outputs D,E,F,...] [--advanced] path/to/file.xlsx path/to/outfile.dmn");
+      sb.append("Usage: java -jar ...jar [--inputs A,B,C,..] [--outputs D,E,F,...] [--policy (UNIQUE,FIRST,PRIORITY,COLLECT,RULE_ORDER,OUTPUT_ORDER)] [--advanced] path/to/file.xlsx path/to/outfile.dmn");
       sb.append(LINE_SEPARATOR);
       sb.append("The use of --advanced negates the --input and --output parameters.");
       System.out.println(sb.toString());
@@ -52,15 +53,23 @@ public class CommandLineConverter {
 
     Set<String> inputs = null;
     Set<String> outputs = null;
+    HitPolicy policy = null;
     for (int i = 0; i < args.length - 2; i++) {
       if ("--inputs".equals(args[i])) {
-        inputs = new HashSet<>();
-        inputs.addAll(Arrays.asList(args[i + 1].split(",")));
+        inputs = new HashSet<>(Arrays.asList(args[i + 1].split(",")));
       }
 
       if ("--outputs".equals(args[i])) {
-        outputs = new HashSet<>();
-        outputs.addAll(Arrays.asList(args[i + 1].split(",")));
+        outputs = new HashSet<>(Arrays.asList(args[i + 1].split(",")));
+      }
+
+      if ("--policy".equals(args[i])) {
+        try {
+          policy = HitPolicy.valueOf(args[i].toUpperCase());
+        } catch (Exception e) {
+          System.out.println("Invalid policy argument: " + policy);
+          System.out.println("Continuing without policy...");
+        }
       }
 
       if ("--advanced".equals(args[i])) {
@@ -74,7 +83,7 @@ public class CommandLineConverter {
 
 
     if (inputs != null && outputs != null) {
-      ioStrategy = new StaticInputOutputDetectionStrategy(inputs, outputs);
+      ioStrategy = new StaticInputOutputDetectionStrategy(inputs, outputs, policy);
       converter.setIoDetectionStrategy(ioStrategy);
     }
 

--- a/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/StaticInputOutputDetectionStrategy.java
+++ b/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/StaticInputOutputDetectionStrategy.java
@@ -29,10 +29,16 @@ public class StaticInputOutputDetectionStrategy extends BaseAdapter {
 
   protected Set<String> inputColumns;
   protected Set<String> outputColumns;
+  protected HitPolicy hitPolicy;
 
   public StaticInputOutputDetectionStrategy(Set<String> inputColumns, Set<String> outputColumns) {
+    this(inputColumns, outputColumns, null);
+  }
+
+  public StaticInputOutputDetectionStrategy(Set<String> inputColumns, Set<String> outputColumns, HitPolicy hitPolicy) {
     this.inputColumns = inputColumns;
     this.outputColumns = outputColumns;
+    this.hitPolicy = hitPolicy;
   }
 
   public InputOutputColumns determineInputOutputs(Spreadsheet context) {
@@ -62,7 +68,7 @@ public class StaticInputOutputDetectionStrategy extends BaseAdapter {
 
   @Override
   public HitPolicy determineHitPolicy(Spreadsheet context) {
-    return null;
+    return hitPolicy;
   }
 
   @Override

--- a/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxWorksheetContext.java
+++ b/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxWorksheetContext.java
@@ -59,7 +59,11 @@ public class XlsxWorksheetContext implements Spreadsheet {
 
   public String resolveSharedString(int index) {
     List<CTRst> siElements = sharedStrings.getSi();
-    return siElements.get(index).getT().getValue();
+    return siElements.get(index).getT() == null
+            // returning default cell content (see org.camunda.bpm.dmn.xlsx.XlsxWorksheetConverter.getDefaultCellContent)
+            // in case T is null to avoid NPE
+            ? "-"
+            : siElements.get(index).getT().getValue();
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs when the property t of type T of an object of class CTRst is null, and adds a parameter of type HitPolicy to the constructor of class StaticInputOutputDetectionStrategy